### PR TITLE
Adds outputs mount

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /models
 /embeddings
 /localizations
+/outputs

--- a/compose.yaml
+++ b/compose.yaml
@@ -9,6 +9,7 @@ services:
             - extensions:/stable-diffusion/stable-diffusion-webui/extensions
             - embeddings:/stable-diffusion/stable-diffusion-webui/embeddings
             - localizations:/stable-diffusion/stable-diffusion-webui/localizations
+            - outputs:/stable-diffusion/stable-diffusion-webui/outputs
         ports:
             - 7860:7860
         restart: always
@@ -44,3 +45,9 @@ volumes:
             type: none
             o: bind
             device: ${PWD}/localizations
+    outputs:
+        driver: local
+        driver_opts:
+            type: none
+            o: bind
+            device: ${PWD}/outputs


### PR DESCRIPTION
* Adds named volume for Outputs folder
* Adds Outputs folder to .gitignore

Web UI will automatically store all generated images in the `Outputs/` directory.  Currently these files are not persisted after the container is restarted.  This maps a named volume to persist those images.